### PR TITLE
CI: frontend install fallback

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,7 @@ jobs:
         working-directory: frontend
         run: |
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
 
       - name: Frontend build
         working-directory: frontend


### PR DESCRIPTION
Use npm install if package-lock.json is absent.